### PR TITLE
`transfer` is deprecated use `transferAllowDeath`

### DIFF
--- a/src/scaffolding/extrinsicHelpers.ts
+++ b/src/scaffolding/extrinsicHelpers.ts
@@ -336,7 +336,7 @@ export class ExtrinsicHelper {
 
   /** Balance Extrinsics */
   public static transferFunds(keys: KeyringPair, dest: KeyringPair, amount: Compact<u128> | AnyNumber): Extrinsic {
-    return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transfer(dest.address, amount), keys, ExtrinsicHelper.api.events.balances.Transfer);
+    return new Extrinsic(() => ExtrinsicHelper.api.tx.balances.transferAllowDeath(dest.address, amount), keys, ExtrinsicHelper.api.events.balances.Transfer);
   }
 
   /** Schema Extrinsics */


### PR DESCRIPTION
transfer is deprecated use transferAllowDeath


Note: updating dependencies is not in the scope of this work